### PR TITLE
Fix README placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # AppleCertsCleaner
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/apple_certs_cleaner`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -42,7 +38,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/apple_certs_cleaner. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/apple_certs_cleaner/blob/master/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/tarappo/apple_certs_cleaner. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/tarappo/apple_certs_cleaner/blob/master/CODE_OF_CONDUCT.md).
 
 
 ## License
@@ -51,4 +47,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the AppleCertsCleaner project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/apple_certs_cleaner/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the AppleCertsCleaner project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/tarappo/apple_certs_cleaner/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary
- replace `[USERNAME]` placeholder with `tarappo`
- remove leftover template text from README

## Testing
- `rake` *(fails: cannot load such file -- rspec/core/rake_task)*