### PR TITLE
Add stubbed tests for certificate cleanup

### DIFF
--- a/spec/apple_certs_cleaner_spec.rb
+++ b/spec/apple_certs_cleaner_spec.rb
@@ -3,16 +3,40 @@ RSpec.describe AppleCertsCleaner do
     expect(AppleCertsCleaner::VERSION).not_to be nil
   end
 
-  xit "remove expired pp file" do
+  it "remove expired pp file" do
+    profiles = [
+      { app_id_name: "TestApp1", file_path: "/tmp/app1.mobileprovision", limit_days: -2 },
+      { app_id_name: "TestApp2", file_path: "/tmp/app2.mobileprovision", limit_days: 3 },
+      { app_id_name: "TestApp3", file_path: nil, limit_days: -1 }
+    ]
+
+    allow(AppleCertsInfo).to receive(:provisioning_profile_list).and_return(profiles)
+    allow(File).to receive(:delete)
+
     AppleCertsCleaner.remove_expired_provisioning_profile
+
+    expect(File).to have_received(:delete).with("/tmp/app1.mobileprovision").once
+  end
+
+  it "remove expired cert file" do
+    certs = [
+      { cname: "CertA", limit_days: -1 },
+      { cname: "CertB", limit_days: 5 },
+      { cname: "CertC", limit_days: -10 }
+    ]
+
+    allow(AppleCertsCleaner).to receive(:all_certs_list).and_return(certs)
+    allow(AppleCertsCleaner).to receive(:delete_first_match_keychain)
+
+    AppleCertsCleaner.remove_expired_certificate
+
+    expect(AppleCertsCleaner).to have_received(:delete_first_match_keychain).with(name: "CertA")
+    expect(AppleCertsCleaner).to have_received(:delete_first_match_keychain).with(name: "CertC")
+    expect(AppleCertsCleaner).to have_received(:delete_first_match_keychain).twice
   end
 
   xit "remove duplicate cert file" do
     AppleCertsCleaner.remove_duplicate_certificate
-  end
-
-  xit "remove expired cert file" do
-    AppleCertsCleaner.remove_expired_certificate
   end
 
   xit "remove invalid cert file" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require "bundler/setup"
+$LOAD_PATH.unshift File.expand_path("support", __dir__)
+require "apple_certs_info"
 require "apple_certs_cleaner"
 
 RSpec.configure do |config|

--- a/spec/support/apple_certs_info.rb
+++ b/spec/support/apple_certs_info.rb
@@ -1,0 +1,2 @@
+module AppleCertsInfo
+end


### PR DESCRIPTION
## Summary
- stub `AppleCertsInfo` so library can load without the gem
- add tests for provisioning profile and certificate cleanup
- ensure helper methods are called and system calls are stubbed

## Testing
- `bundle3.2 exec rspec` *(fails: bundler: command not found: rspec)*