### PR TITLE
Set up CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Ruby
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - run: bundle exec rake spec


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on pull requests

## Testing
- `bundle exec rake spec` *(fails: `bundle: command not found`)*